### PR TITLE
Correct disable AR/VR buttons

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -80,13 +80,17 @@ function setupButtonsXR() {
   /* Setup AR / VR buttons */
   const arButton = document.getElementById("ar-button");
   if (arButton) {
-    arButton.dataset.supported = engine.arSupported;
-    arButton.addEventListener("click", () => requestSession("immersive-ar"));
+    arButton.dataset.supported = engine.arSupported ? '1' : '0';
+    if (engine.arSupported) {
+      arButton.addEventListener("click", () => requestSession("immersive-ar"));
+    }
   }
   const vrButton = document.getElementById("vr-button");
   if (vrButton) {
-    vrButton.dataset.supported = engine.vrSupported;
-    vrButton.addEventListener("click", () => requestSession("immersive-vr"));
+    vrButton.dataset.supported = engine.vrSupported ? '1' : '0';
+    if (engine.vrSupported) {
+      vrButton.addEventListener("click", () => requestSession("immersive-vr"));
+    }
   }
 }
 


### PR DESCRIPTION
Small update to `index.js` to correctly enable and disable the VR (and AR) buttons. With this change, they are greyed out and do not handle the click event when VR is not supported.